### PR TITLE
docs: update prompt example name

### DIFF
--- a/docs/prompts/README.md
+++ b/docs/prompts/README.md
@@ -2,4 +2,4 @@
 
 Place reusable prompt snippets in this folder (files ending in `.prompt.md`).
 
-*Example*: `Generate feature prompt.md`
+*Example*: `generate_feature.prompt.md`


### PR DESCRIPTION
## Summary
- fix prompt playbook example to use underscored filename without spaces

## Testing
- `./gradlew test` *(fails: Plugin [id: 'com.google.devtools.ksp'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899bb058a648323af6b30f4d26a1e1b