### PR TITLE
docs: add Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,23 @@
+# Copilot Instructions for MyAssistant
+
+## Coding Style
+
+- Follow the official [Kotlin coding conventions](https://kotlinlang.org/docs/coding-conventions.html).
+- Use four spaces for indentation and keep lines under 100 characters when possible.
+- Name classes and interfaces in `PascalCase`; functions and variables use `camelCase`.
+- Avoid wildcard imports; explicitly import required classes.
+- Package names are all lowercase and start with `com.magter.myassistant`.
+  - Do not use underscores or uppercase letters in package names.
+
+## Commit and Test Workflow
+
+1. Pull the latest changes from the repository.
+2. Make small, focused commits with descriptive messages.
+3. Run `./gradlew test` to ensure all tests pass before committing.
+4. Verify a clean working tree with `git status`.
+
+## Expectations for AI Agents
+
+- Adhere to the coding style and workflow above.
+- Do not create new branches.
+- Include a summary of changes and test results in the pull request description.


### PR DESCRIPTION
## Summary
- outline Kotlin coding conventions and package naming
- describe commit/test workflow and expectations for AI agents

## Testing
- `./gradlew test` *(fails: Plugin [id: 'com.google.devtools.ksp', version: '2.1.20-1.0.16'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899bdaaf56c8323acaf0d0f80f860e3