### PR TITLE
Move MainActivity to app module

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,15 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MyAssistant"
-        tools:targetApi="31" />
+        tools:targetApi="31">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
 
 </manifest>

--- a/app/src/main/java/com/magter/myassistant/MainActivity.kt
+++ b/app/src/main/java/com/magter/myassistant/MainActivity.kt
@@ -1,9 +1,9 @@
-package com.magter.myassistant.ui
+package com.magter.myassistant
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.material3.Text
+import com.magter.myassistant.ui.MainScreen
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -11,7 +11,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            Text("Hello from :feature:ui!")
+            MainScreen()
         }
     }
 }

--- a/feature/ui/src/main/java/com/magter/myassistant/ui/MainScreen.kt
+++ b/feature/ui/src/main/java/com/magter/myassistant/ui/MainScreen.kt
@@ -1,0 +1,9 @@
+package com.magter.myassistant.ui
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun MainScreen() {
+    Text("Hello from :feature:ui!")
+}


### PR DESCRIPTION
## Summary
- Move MainActivity into app module and delegate UI to feature:ui
- Register MainActivity in Android manifest
- Expose MainScreen composable from feature:ui

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899c72f0f0c8323bed31f523704232e