### PR TITLE
Add placeholders and basic tests for model and feature modules

### DIFF
--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -12,4 +12,5 @@ dependencies {
     implementation(libs.kotlin.stdlib)
     implementation(libs.coroutines.core)
     // Add other dependencies specific to the model layer
+    testImplementation(libs.junit)
 }

--- a/core/model/src/main/kotlin/com/magter/myassistant/core/model/User.kt
+++ b/core/model/src/main/kotlin/com/magter/myassistant/core/model/User.kt
@@ -1,0 +1,9 @@
+package com.magter.myassistant.core.model
+
+/**
+ * Represents a simple user in the system.
+ */
+data class User(
+    val id: String,
+    val name: String
+)

--- a/core/model/src/test/kotlin/com/magter/myassistant/core/model/UserTest.kt
+++ b/core/model/src/test/kotlin/com/magter/myassistant/core/model/UserTest.kt
@@ -1,0 +1,13 @@
+package com.magter.myassistant.core.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UserTest {
+    @Test
+    fun userPropertiesAreAccessible() {
+        val user = User(id = "1", name = "Alice")
+        assertEquals("1", user.id)
+        assertEquals("Alice", user.name)
+    }
+}

--- a/feature/llm/src/main/kotlin/com/magter/myassistant/feature/llm/LlmService.kt
+++ b/feature/llm/src/main/kotlin/com/magter/myassistant/feature/llm/LlmService.kt
@@ -1,0 +1,11 @@
+package com.magter.myassistant.feature.llm
+
+/**
+ * Provides language-model capabilities.
+ */
+interface LlmService {
+    /**
+     * Generates a response for the given prompt.
+     */
+    fun generate(prompt: String): String
+}

--- a/feature/llm/src/test/kotlin/com/magter/myassistant/feature/llm/LlmServiceTest.kt
+++ b/feature/llm/src/test/kotlin/com/magter/myassistant/feature/llm/LlmServiceTest.kt
@@ -1,0 +1,16 @@
+package com.magter.myassistant.feature.llm
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LlmServiceTest {
+    private class ConstantLlmService : LlmService {
+        override fun generate(prompt: String): String = "response"
+    }
+
+    @Test
+    fun generateReturnsResponse() {
+        val service = ConstantLlmService()
+        assertEquals("response", service.generate("prompt"))
+    }
+}

--- a/feature/speech/src/main/kotlin/com/magter/myassistant/feature/speech/SpeechRecognizer.kt
+++ b/feature/speech/src/main/kotlin/com/magter/myassistant/feature/speech/SpeechRecognizer.kt
@@ -1,0 +1,11 @@
+package com.magter.myassistant.feature.speech
+
+/**
+ * Defines contract for speech recognition components.
+ */
+interface SpeechRecognizer {
+    /**
+     * Converts the provided audio data into text.
+     */
+    fun recognize(audio: ByteArray): String
+}

--- a/feature/speech/src/test/kotlin/com/magter/myassistant/feature/speech/SpeechRecognizerTest.kt
+++ b/feature/speech/src/test/kotlin/com/magter/myassistant/feature/speech/SpeechRecognizerTest.kt
@@ -1,0 +1,16 @@
+package com.magter.myassistant.feature.speech
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SpeechRecognizerTest {
+    private class EchoRecognizer : SpeechRecognizer {
+        override fun recognize(audio: ByteArray): String = "echo"
+    }
+
+    @Test
+    fun recognizeReturnsExpectedString() {
+        val recognizer = EchoRecognizer()
+        assertEquals("echo", recognizer.recognize(byteArrayOf()))
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `User` data class for core model module
- define speech recognition and LLM service interfaces
- add simple unit tests and JUnit dependency

## Testing
- `./gradlew :core:model:test :feature:speech:testDebugUnitTest :feature:llm:testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899c732a8548323893c25c4b0c37f6b